### PR TITLE
Update README.md for composer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library does not have any requirements.
 
 Using composer:
 
-    composer install mtgsdk/mtgsdk
+    composer require mtgsdk/mtgsdk:dev-master
 
 ## Usage
 


### PR DESCRIPTION
This change to the readme will get people up and running faster.
Currently packagist only contains the dev-master branch which requires asking for it explicitly, or implicitly by setting the minimum-stability version of your project to dev.